### PR TITLE
Upgade to curator 5.6.0

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,10 @@ cerebro/cerebro-0.6.6.tgz:
   size: 51199362
   object_id: fda10e6d-aeba-47b6-6f0d-fa313cffc109
   sha: 69bc2aafb2c5966163c44b19f2768eb9f497aac3
-curator/elasticsearch-curator-5.2.0.tar.gz:
-  size: 206905
-  object_id: cb6abe98-70e9-49ba-57b2-4704588ab7ec
-  sha: dd73ebd695d1f36028d4fb7e3dc2f4f71f602190
+curator/elasticsearch-curator-5.6.0.tar.gz:
+  size: 221555
+  object_id: ca513722-6b00-4acd-7fcc-2fef3a880a10
+  sha: 9d8764d628c2db0a0a425e1b574fc97a5aea3fa0
 curator/vendor/PyYAML-3.12.tar.gz:
   size: 253011
   object_id: c437dff0-e2db-4d48-9c12-626160760901

--- a/packages/curator/packaging
+++ b/packages/curator/packaging
@@ -5,4 +5,4 @@ export PATH=/var/vcap/packages/python3/bin:$PATH LD_LIBRARY_PATH=/var/vcap/packa
 # --no-index prevents contacting pypi to download packages
 # --find-links tells pip where to look for the dependancies
 # --prefix installation prefix where lib, bin and other top-level folders are placed
-pip3 install --no-index --find-links ./curator/vendor/ --prefix=${BOSH_INSTALL_TARGET} curator/elasticsearch-curator-5.2.0.tar.gz
+pip3 install --no-index --find-links ./curator/vendor/ --prefix=${BOSH_INSTALL_TARGET} curator/elasticsearch-curator-5.6.0.tar.gz

--- a/packages/curator/spec
+++ b/packages/curator/spec
@@ -5,7 +5,7 @@ dependencies:
   - python3
 
 files:
-  - curator/elasticsearch-curator-5.2.0.tar.gz
+  - curator/elasticsearch-curator-5.6.0.tar.gz
   - curator/vendor/PyYAML-3.12.tar.gz
   - curator/vendor/click-6.7-py2.py3-none-any.whl
   - curator/vendor/urllib3-1.22-py2.py3-none-any.whl


### PR DESCRIPTION
According to this Issue, in order to use curator with ES 6.x we need
atleast curator 5.5.4.
https://github.com/elastic/curator/issues/1261#issuecomment-415667596