### PR TITLE
Update stemcell to xenial

### DIFF
--- a/ci/jobs.yml
+++ b/ci/jobs.yml
@@ -27,12 +27,12 @@ jobs:
       - get: logsearch-boshrelease
         trigger: true
         passed: [logsearch-boshrelease]
-      - get: aws-stemcell
+      - get: aws-stemcell-xenial
     - task: build-manifest
       file: logsearch-boshrelease/ci/tasks/build-manifest.yml
     - put: chai-deployment
       params:
         manifest: build-manifest/logsearch-boshrelease/logsearch.yml
-        stemcells: [aws-stemcell/*.tgz]
+        stemcells: [aws-stemcell-xenial/*.tgz]
         releases: [logsearch-tarball/*.tgz]
 

--- a/ci/resources.yml
+++ b/ci/resources.yml
@@ -6,11 +6,11 @@ resources:
     branch: develop
     private_key: {{logsearch-boshrelease-access-key}}
 
-- name: aws-stemcell
+- name: aws-stemcell-xenial
   type: bosh-io-stemcell
   check_every: 10080m # 1week
   source:
-    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+    name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
 
 - name: deployment
   type: bosh-deployment


### PR DESCRIPTION
Updates stemcell to xenial and renames stemcell resource so Concourse
 does not get confused by xenial's lower version numbers