### PR TITLE
missed spec file.

### DIFF
--- a/packages/logstash/spec
+++ b/packages/logstash/spec
@@ -5,7 +5,7 @@ dependencies:
   - java8
 
 files:
-  - logstash/logstash-6.3.2.tar.gz
+  - logstash/logstash-6.4.0.tar.gz
   - logstash/logstash-filter-alter-3.0.2.zip
   - logstash/logstash-filter-translate-3.0.3.zip
   - logstash/logstash-input-relp-3.0.2.zip


### PR DESCRIPTION
Fixes this [broken build](https://ci.fr.cloud.gov/teams/main/pipelines/deploy-logsearch/jobs/deploy-logsearch-platform-development/builds/341)

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>