### PR TITLE
increase smoke test timeout to one hour.

### DIFF
--- a/jobs/smoke_tests/templates/run.sh
+++ b/jobs/smoke_tests/templates/run.sh
@@ -44,7 +44,7 @@ INGEST="nc $INGESTOR_HOST $INGESTOR_PORT"
 echo "SENDING $LOG"
 echo "$LOG" | $INGEST > /dev/null
 
-TRIES=${1:-600}
+TRIES=${1:-720}
 SLEEP=5
 
 echo -n "Polling for $TRIES seconds"


### PR DESCRIPTION
The [prod smoke tests](https://ci.fr.cloud.gov/teams/main/pipelines/deploy-logsearch/jobs/smoke-tests-platform-production) keep failing because the smoke test log message isn't making it through the ingestion pipeline fast enough.

This is designed to be a short-term fix to unblock deployments.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>