### PR TITLE
added reporting key field.

### DIFF
--- a/jobs/kibana/spec
+++ b/jobs/kibana/spec
@@ -67,6 +67,9 @@ properties:
   kibana.apm_enabled:
     description: "Enable Kibana APM ui; should be set to `false` in a multi-tenant deployment."
     default: false
+  kibana.reporting_key:
+    description: "Define a reporting key to prevent issues with exporting a report in a load balanced scenario."
+    default: CloudFoundry123!
   kibana.config_options:
     description: "Additional options to append to kibana's config.yml (YAML format)."
     default: ~

--- a/jobs/kibana/templates/config/kibana.conf.erb
+++ b/jobs/kibana/templates/config/kibana.conf.erb
@@ -95,6 +95,9 @@ xpack.grokdebugger.enabled: <%= p("kibana.grokdebugger_enabled") %>
 # configure apm
 xpack.apm.ui.enabled: <%= p("kibana.apm_enabled") %>
 
+# set reporting key for load balanced scenarios
+xpack.reporting.encryptionKey: <%= p("kibana.reporting_key") %>
+
 # disable x-pack
 xpack.monitoring.enabled: false
 xpack.graph.enabled: false


### PR DESCRIPTION
added option for a custom reporting key for kibana. this is to work
around a customer-reported issue with exporting reports. while kibana
will create a reporting key, this can break in load balanced scenarios
because each kibana instance will create their own.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>