### PR TITLE
Migrate data

### DIFF
--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -9,6 +9,7 @@ templates:
   bin/drain.erb: bin/drain
   bin/post-deploy.erb: bin/post-deploy
   bin/post-start.erb: bin/post-start
+  bin/pre-start.erb: bin/pre-start
   bin/elasticsearch_ctl: bin/elasticsearch_ctl
   bin/monit_debugger: bin/monit_debugger
   config/config.yml.erb: config/elasticsearch.yml
@@ -133,3 +134,7 @@ properties:
   elasticsearch.snapshots.repository:
     description: Repository name for automatic snapshots
     default: ''
+  elasticsearch.migrate_data_path:
+    description: move data path from /var/vcap/store/elasticsearch/logsearch to /var/vcap/store/elasticsearch
+    default: false
+

--- a/jobs/elasticsearch/templates/bin/pre-start.erb
+++ b/jobs/elasticsearch/templates/bin/pre-start.erb
@@ -1,0 +1,6 @@
+<% if p("elasticsearch.migrate_data_path") %>
+if [[ -f /var/vcap/store/elasticsearch/logsearch ]]; then
+    cp -pR /var/vcap/store/elasticsearch/logsearch/nodes /var/vcap/store/elasticsearch
+    rm -rf /var/vcap/store/elasticsearch/logsearch/nodes
+fi
+<% end %>

--- a/jobs/elasticsearch/templates/bin/pre-start.erb
+++ b/jobs/elasticsearch/templates/bin/pre-start.erb
@@ -1,5 +1,5 @@
 <% if p("elasticsearch.migrate_data_path") %>
-if [[ -f /var/vcap/store/elasticsearch/logsearch ]]; then
+if [[ -d /var/vcap/store/elasticsearch/logsearch ]]; then
     cp -pR /var/vcap/store/elasticsearch/logsearch/nodes /var/vcap/store/elasticsearch
     rm -rf /var/vcap/store/elasticsearch/logsearch/nodes
 fi


### PR DESCRIPTION
we have our data path at /var/vcap/store/elasticsearch/logsearch, and upstream has it at /var/vcap/store/elasticsearch

This adds a script to get us in line with upstream.