### PR TITLE
unlink nodes for special case in production

### DIFF
--- a/jobs/elasticsearch/templates/bin/pre-start.erb
+++ b/jobs/elasticsearch/templates/bin/pre-start.erb
@@ -1,6 +1,12 @@
 #!/bin/bash
+set -e
+set -x
+
 <% if p("elasticsearch.migrate_data_path") %>
 if [[ -d /var/vcap/store/elasticsearch/logsearch ]]; then
+    if [[ -h /var/vcap/store/elasticsearch/nodes ]]; then
+        unlink /var/vcap/store/elasticsearch/nodes
+    fi
     cp -pR /var/vcap/store/elasticsearch/logsearch/nodes /var/vcap/store/elasticsearch
     rm -rf /var/vcap/store/elasticsearch/logsearch/
 fi


### PR DESCRIPTION
somehow, production data nodes are different from staging and development. 
in non-production, prior to upgrading, we had a single directory under `/var/vcap/store/elasticsearch`: `logsearch` and `nodes` was a subdirectory of that. 
in production, under `/var/vcap/store/elasticsearch/`, we have `logsearch` and also `nodes` as a symlink to `/var/vcap/store/elasticsearch/logsearch/nodes`

This is an attempt to work around that
