### PR TITLE
fail faster with smoke tests

### DIFF
--- a/jobs/smoke_tests/templates/run.sh
+++ b/jobs/smoke_tests/templates/run.sh
@@ -44,7 +44,7 @@ INGEST="nc $INGESTOR_HOST $INGESTOR_PORT"
 echo "SENDING $LOG"
 echo "$LOG" | $INGEST > /dev/null
 
-TRIES=${1:-720}
+TRIES=${1:-300}
 SLEEP=5
 
 echo -n "Polling for $TRIES seconds"


### PR DESCRIPTION
when the smoke tests succeed, they generally do so in 10 seconds or less. When they fail, they take the whole timeout period here to do so. This allows the tests to fail faster, freeing up resources and giving faster feedback